### PR TITLE
Fix QueryRoutes 

### DIFF
--- a/node/queryroutes.md
+++ b/node/queryroutes.md
@@ -12,11 +12,11 @@ This endpoint allows you to probe a route to see the fee and if the destination 
 {% api-method-spec %}
 {% api-method-request %}
 {% api-method-query-parameters %}
-{% api-method-parameter name="pub\_key" type="string" %}
+{% api-method-parameter name="pub\_key" type="string" required=true %}
 destination pub key
 {% endapi-method-parameter %}
 
-{% api-method-parameter name="amt" type="number" %}
+{% api-method-parameter name="amt" type="number" required=true %}
 amount in sats
 {% endapi-method-parameter %}
 {% endapi-method-query-parameters %}

--- a/node/queryroutes.md
+++ b/node/queryroutes.md
@@ -1,6 +1,6 @@
 # QueryRoutes
 
-{% api-method method="get" host="https://api.lnpay.co" path="/v1/default/payment/queryroutes?pub\_key=&amt=" %}
+{% api-method method="get" host="https://api.lnpay.co" path="/v1/node/default/payments/queryroutes?pub\_key=&amt=" %}
 {% api-method-summary %}
 Get QueryRoutes
 {% endapi-method-summary %}


### PR DESCRIPTION
Hi. Noticed some errors in the documentation. 

1. Fixed query routes URL path (now matching the curl example below)
2. URL parameters are required (otherwise API responds HTTP 400)

There is also no example for query routes included in the Postman collection hosted here https://www.postman.com/collections/fc4f2351a12b3446841c

Thought this might help other users.
